### PR TITLE
Rollbacks for deadlocks

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb
@@ -66,6 +66,9 @@ module ActiveRecord
       end
 
       def commit!
+        if uncommittable?
+          raise ActiveRecord::TransactionIsolationError, "cannot set state committed when already #{state.to_s}"
+        end
         @state = :committed
       end
 
@@ -164,11 +167,14 @@ module ActiveRecord
       end
 
       def rollback
-        connection.rollback_to_savepoint(savepoint_name)
+        connection.rollback_to_savepoint(savepoint_name) unless state.invalidated?
         super
       end
 
       def commit
+        if state.invalidated?
+          raise ActiveRecord::StatementInvalid, "cannot commit after transaction invalidated"
+        end
         connection.release_savepoint(savepoint_name)
         super
       end
@@ -187,11 +193,14 @@ module ActiveRecord
       end
 
       def rollback
-        connection.rollback_db_transaction
+        connection.rollback_db_transaction unless state.invalidated?
         super
       end
 
       def commit
+        if state.invalidated?
+          raise ActiveRecord::StatementInvalid, "cannot commit after transaction invalidated"
+        end
         connection.commit_db_transaction
         super
       end
@@ -222,6 +231,9 @@ module ActiveRecord
       def commit_transaction
         @connection.lock.synchronize do
           transaction = @stack.last
+          if transaction.state.invalidated?
+            raise ActiveRecord::StatementInvalid, "cannot commit after transaction invalidated"
+          end
 
           begin
             transaction.before_commit_records
@@ -237,7 +249,7 @@ module ActiveRecord
       def rollback_transaction(transaction = nil)
         @connection.lock.synchronize do
           transaction ||= @stack.pop
-          transaction.rollback
+          transaction.rollback unless transaction.state.invalidated?
           transaction.rollback_records
         end
       end
@@ -249,9 +261,11 @@ module ActiveRecord
             yield
           rescue Exception => error
             if transaction
+              transaction.state.invalidate! if error.is_a? ActiveRecord::TransactionRollbackError
               rollback_transaction
               after_failure_actions(transaction, error)
             end
+            # This cascades up to this same rescue in the enclosing within_new_transaction's, if any
             raise
           ensure
             unless error

--- a/activerecord/test/cases/adapters/mysql2/nested_deadlock_test.rb
+++ b/activerecord/test/cases/adapters/mysql2/nested_deadlock_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/connection_helper"
+
+module ActiveRecord
+  class Mysql2NestedDeadlockTest < ActiveRecord::Mysql2TestCase
+    self.use_transactional_tests = false
+
+    class Sample < ActiveRecord::Base
+      self.table_name = "samples"
+    end
+
+    setup do
+      @abort, Thread.abort_on_exception = Thread.abort_on_exception, false
+
+      @connection = ActiveRecord::Base.connection
+      @connection.clear_cache!
+
+      @connection.transaction do
+        @connection.drop_table "samples", if_exists: true
+        @connection.create_table("samples") do |t|
+          t.integer "value"
+        end
+      end
+
+      Sample.reset_column_information
+    end
+
+    teardown do
+      ActiveRecord::Base.connection.disconnect!
+      ActiveRecord::Base.establish_connection
+      @connection.drop_table "samples", if_exists: true
+
+      Thread.abort_on_exception = @abort
+    end
+
+    test "deadlock correctly raises Deadlocked inside nested SavepointTransaction" do
+      assert_raises(ActiveRecord::Deadlocked) do
+        barrier = Concurrent::CyclicBarrier.new(2)
+
+        s1 = Sample.create value: 1
+        s2 = Sample.create value: 2
+
+        begin
+          thread = Thread.new do
+            # Start a RealTransaction
+            Sample.transaction(:requires_new => false) do
+              # Start a SavepointTransaction inside it
+              Sample.transaction(:requires_new => true) do
+                s1.lock!
+                barrier.wait
+                s2.update_attributes value: 1
+              end
+            end
+          end
+
+          begin
+            # Start a RealTransaction
+            Sample.transaction(:requires_new => false) do
+              # Start a SavepointTransaction inside it
+              Sample.transaction(:requires_new => true) do
+                s2.lock!
+                barrier.wait
+                s1.update_attributes value: 2
+              end
+            end
+          ensure
+            thread.join
+          end
+
+        rescue ActiveRecord::StatementInvalid => e
+          if /SAVEPOINT active_record_. does not exist: ROLLBACK TO SAVEPOINT/ =~ e.to_s
+            assert nil, "ROLLBACK TO SAVEPOINT query issued for savepoint that no longer exists due to deadlock: #{e}"
+          else
+            raise e
+          end
+        end
+      end
+    end
+
+  end
+end

--- a/activerecord/test/cases/adapters/mysql2/transaction_test_2.rb
+++ b/activerecord/test/cases/adapters/mysql2/transaction_test_2.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/connection_helper"
+
+module ActiveRecord
+  class Mysql2TransactionTest < ActiveRecord::Mysql2TestCase
+    self.use_transactional_tests = false
+
+    class Sample < ActiveRecord::Base
+      self.table_name = "samples"
+    end
+
+    setup do
+      @abort, Thread.abort_on_exception = Thread.abort_on_exception, false
+
+      @connection = ActiveRecord::Base.connection
+      @connection.clear_cache!
+
+      @connection.transaction do
+        @connection.drop_table "samples", if_exists: true
+        @connection.create_table("samples") do |t|
+          t.integer "value"
+        end
+      end
+
+      Sample.reset_column_information
+    end
+
+    teardown do
+      @connection.drop_table "samples", if_exists: true
+
+      Thread.abort_on_exception = @abort
+    end
+
+    test "deadlock correctly raises Deadlocked inside nested SavepointTransaction" do
+      assert_raises(ActiveRecord::Deadlocked) do
+        barrier = Concurrent::CyclicBarrier.new(2)
+
+        s1 = Sample.create value: 1
+        s2 = Sample.create value: 2
+
+        begin
+          thread = Thread.new do
+            # Start a RealTransaction
+            Sample.transaction(:requires_new => false) do
+              # Start a SavepointTransaction inside it
+              Sample.transaction(:requires_new => true) do
+                s1.lock!
+                barrier.wait
+                s2.update_attributes value: 1
+              end
+            end
+          end
+
+          begin
+            # Start a RealTransaction
+            Sample.transaction(:requires_new => false) do
+              # Start a SavepointTransaction inside it
+              Sample.transaction(:requires_new => true) do
+                s2.lock!
+                barrier.wait
+                s1.update_attributes value: 2
+              end
+            end
+          ensure
+            thread.join
+          end
+
+        rescue ActiveRecord::StatementInvalid => e
+          if /SAVEPOINT active_record_. does not exist: ROLLBACK TO SAVEPOINT/ =~ e.to_s
+            assert nil, "ROLLBACK TO SAVEPOINT query issued for savepoint that no longer exists due to deadlock: #{e}"
+          else
+            raise e
+          end
+        end
+      end
+    end
+
+  end
+end

--- a/activerecord/test/cases/adapters/postgresql/transaction_nested_test.rb
+++ b/activerecord/test/cases/adapters/postgresql/transaction_nested_test.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+require "cases/helper"
+require "support/connection_helper"
+require "concurrent/atomic/cyclic_barrier"
+
+module ActiveRecord
+  class PostgresqlTransactionNestedTest < ActiveRecord::PostgreSQLTestCase
+    self.use_transactional_tests = false
+
+    class Sample < ActiveRecord::Base
+      self.table_name = "samples"
+    end
+
+    setup do
+      @abort, Thread.abort_on_exception = Thread.abort_on_exception, false
+
+      @connection = ActiveRecord::Base.connection
+
+      @connection.transaction do
+        @connection.drop_table "samples", if_exists: true
+        @connection.create_table("samples") do |t|
+          t.integer "value"
+        end
+      end
+
+      Sample.reset_column_information
+    end
+
+    teardown do
+      @connection.reconnect!
+      @connection.drop_table "samples", if_exists: true
+
+      Thread.abort_on_exception = @abort
+    end
+
+    test "unserializable transaction raises SerializationFailure inside nested SavepointTransaction" do
+      assert_raises(ActiveRecord::SerializationFailure) do
+        before = Concurrent::CyclicBarrier.new(2)
+        after = Concurrent::CyclicBarrier.new(2)
+
+        begin
+          thread = Thread.new do
+            with_warning_suppression do
+              Sample.transaction(isolation: :serializable, requires_new: false) do
+                Sample.transaction(requires_new: true) do
+                  before.wait
+                  Sample.create value: Sample.sum(:value)
+                  after.wait
+                end
+              end
+            end
+          end
+
+          begin
+            with_warning_suppression do
+              Sample.transaction(isolation: :serializable, requires_new: false) do
+                Sample.transaction(requires_new: true) do
+                  before.wait
+                  Sample.create value: Sample.sum(:value)
+                  after.wait
+                end
+              end
+            end
+          ensure
+            thread.join
+          end
+        end
+      end
+    end
+
+    test "deadlock raises Deadlocked inside nested SavepointTransaction" do
+      with_warning_suppression do
+        assert_raises(ActiveRecord::Deadlocked) do
+          barrier = Concurrent::CyclicBarrier.new(2)
+
+          s1 = Sample.create value: 1
+          s2 = Sample.create value: 2
+
+          begin
+            thread = Thread.new do
+              Sample.transaction(requires_new: false) do
+                Sample.transaction(requires_new: true) do
+                  s1.lock!
+                  barrier.wait
+                  s2.update_attributes value: 1
+                end
+              end
+            end
+
+            begin
+              Sample.transaction(requires_new: false) do
+                Sample.transaction(requires_new: true) do
+                  s2.lock!
+                  barrier.wait
+                  s1.update_attributes value: 2
+                end
+              end
+            ensure
+              thread.join
+            end
+          end
+        end
+      end
+    end
+
+    private
+
+      def with_warning_suppression
+        #log_level = ActiveRecord::Base.connection.client_min_messages
+        #ActiveRecord::Base.connection.client_min_messages = "error"
+        yield
+      ensure
+        #ActiveRecord::Base.connection.client_min_messages = log_level
+      end
+  end
+end


### PR DESCRIPTION
### Summary of the issue

ActiveRecord offers nested transactions, when `requires_new: true` is passed to `ActiveRecord::ConnectionAdapters::DatabaseStatements#transaction`.

In MySQL, this is not simply a matter of nesting the `BEGIN` and `COMMIT`. Instead, ActiveRecord creates a nested `SavepointTransaction` with its method `create_savepoint`, and rolls it back if necessary with `exec_rollback_to_savepoint`.

As described in #30752 , currently a deadlock inside a nested MySQL transaction results in ActiveRecord invoking `exec_rollback_to_savepoint` in an attempt to undo the inner transaction(s), before proceeding to the outermost transaction where a simple `ROLLBACK` is issued.

None of these SQL statements are necessary. By the time ActiveRecord sees the `ActiveRecord::Deadlocked` error, as far as the MySQL server is concerned, the transaction is no longer valid and none of its savepoints exist. It so happens that the server tolerates a `ROLLBACK` query (it's a no-op since the client is no longer in a transaction).

But the `ROLLBACK TO SAVEPOINT` is an error. The server emits `ERROR 1305 (42000): SAVEPOINT foo does not exist`, which ActiveRecord sees as a `Mysql2::Error` exception.

Because ActiveRecord handles exceptions within nested transactions by rolling back each savepoint in turn, a deadlock inside a nested transaction raises this unnecessary error 100% of the time.

This is particularly irksome because deadlocks are not the application's "fault"; they are a quirk of ACID design and [can happen](https://dev.mysql.com/doc/refman/5.7/en/innodb-deadlocks-handling.html) to almost any nontrivial transaction under the wrong circumstances.

### Summary of this change

This pull request adds an additional state to `TransactionState` which indicates that the transaction has been `:invalidated`. As the `ActiveRecord::Deadlocked` error percolates to the outermost `transaction`, each state on the stack is invalidated in turn.

With this PR, an invalidated transaction continues to invoke [after_rollback callbacks](https://github.com/rails/rails/blob/9befc197f926/activerecord/lib/active_record/transactions.rb#L176-L189) as each nested transaction unwinds. It simply omits the `exec_rollback_to_savepoint` call, so it doesn't ask the server to roll back a savepoint that no longer exists. Thus the unnecessary error is avoided.

A test is provided that forces a deadlock inside a nested transaction. It confirms that the exception raised out of that code is no longer `ActiveRecord::StatementInvalid` but rather `ActiveRecord::Deadlocked`. The test passes in this branch and fails in Rails `master`. (I pushed the test commit first and got Travis to put [that failure](https://travis-ci.org/rails/rails/builds/289595574) on the record.)

### Other Information

After a transaction is invalidated, this PR also skips the final `exec_rollback_db_transaction`, because there is no point to issuing a no-op `ROLLBACK`. (It wouldn't really hurt anything, just waste a millisecond for the query.)

Additionally, with this PR, just in case some exception handler or callback tries to `commit` after a transaction has deadlocked, a `ActiveRecord::StatementInvalid` is raised. This would have been a serious but probably silent logic error otherwise.

### Commentary on alternatives to the new state

The approach I decided to take was adding a `TransactionState`, because my general feeling is that if a state is being stored in an object, the best design is to model the real-world state accurately.

Another alternative would have been to trust that the `ActiveRecord::Deadlocked` exception percolates to the outermost transaction (which is a reasonable assumption), without being rescued by any application which then naively executes code that tries to issue a query (which may or may not be a reasonable assumption). If those assumptions are accurate, one could instead avoid the `exec_rollback_db_transaction` at each nested transaction level "individually."

In my view, the main argument for that alternative design would be that my new `TransactionState` doesn't actually percolate up to the top level immediately _anyway_ (each level only tracks its children not its parent), so my implementation doesn't really fix all the states immediately in any case, so why bother fixing any of them.

To this, I would point out that with the new state it's easier to raise an exception with [a clearer error message](https://github.com/rails/rails/pull/30921/commits/c043412d149eff7a3eed7e85ffa04c628d47fe94#diff-52c8dd8e01c039c37b33b3fcbdfe406aR70).

### Commentary on the Postgresql test

I don't personally use Postgresql nor SQLite and can't say I'm terribly familiar with them. I attempted to write a test for Postgres that confirmed correct behavior both of `SerializationFailure` and `Deadlocked` in a nested transaction just like the existing `PostgresqlTransactionTest` does in a non-nested transaction.

As Travis [verifies](https://travis-ci.org/rails/rails/builds/289595574), in 1e8c7654483d38c6dbfa04e79978fbae247ad50d, both my new Postgres tests pass against the existing `master` branch, which makes that not a very useful test.

I believe that after the Postgres server invalidates the transaction, either the client must be resetting the connection's status or the server effectively does that automatically. Either way, the test is left in a state where, while commands can be issued, the client thinks it's in a transaction but the server disagrees. This could probably be tested better.

Still, I think having a test that verifies correct Rails behavior is at least a good jumping-off point to one that also errors on incorrect behavior, so here it is anyway.

I did not attempt to do the same with the sqlite3 adapter but would be open to trying.

### Commentary on invoking after_rollback callbacks

I'm not an expert on the callbacks offered for transactions, either after commit or after rollback. This change deliberately continues to invoke the after-rollback callbacks, even though the connection is in a state where any queries will raise an exception.

I believe this is the correct thing to do because any such callback should already be assuming that the connection is invalid.

I'm reasonably confident I understand the logic here, but more eyes on that design point specifically would of course be appreciated.